### PR TITLE
Add Ctrl+Q to Quit action

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ GIT HEAD
   lot smoother, hopefully. (cf. issue #83) (EXPERIMENTAL)
 - Click-dragging with the mouse middle-button is for panning only,
   not to start a selection anymore. (cf. issue #76) (EXPERIMENTAL)
+- Add Ctrl+Q to Quit action
 
 
 0.5.1  2023-07-17  A summer'23 hot-fix release.

--- a/src/qpwgraph_form.ui
+++ b/src/qpwgraph_form.ui
@@ -495,7 +495,7 @@
     <string>Quit this application program</string>
    </property>
    <property name="shortcut">
-    <string/>
+    <string>Ctrl+Q</string>
    </property>
   </action>
   <action name="editSelectAllAction">


### PR DESCRIPTION
Very simple change to add Ctrl+Q as a keyboard shortcut to quit qpwgraph.
