### PR TITLE
fix: [memory] Fix memory leak in PipeWire thread loop initialization

### DIFF
--- a/src/qpwgraph_pipewire.cpp
+++ b/src/qpwgraph_pipewire.cpp
@@ -712,8 +712,6 @@ bool qpwgraph_pipewire::open (void)
 	spa_list_init(&m_data->pending);
 	m_data->pending_seq = 0;
 
-	m_data->node_names = new Data::NodeNames;
-
 	m_data->loop = pw_thread_loop_new("qpwgraph_thread_loop", nullptr);
 	if (m_data->loop == nullptr) {
 		qDebug("pw_thread_loop_new: Can't create thread loop.");
@@ -762,6 +760,7 @@ bool qpwgraph_pipewire::open (void)
 	m_data->pending_seq = 0;
 	m_data->last_seq = 0;
 	m_data->error = false;
+	m_data->node_names = new Data::NodeNames;
 
 	pw_thread_loop_start(m_data->loop);
 	pw_thread_loop_unlock(m_data->loop);


### PR DESCRIPTION
Move node_names initialization to after error checking to prevent potential 
memory leaks. This ensures resources are only allocated after confirming 
the thread loop and other critical components are properly set up.

The change improves resource management by:
- Delaying node_names allocation until after validation checks
- Reducing risk of memory leaks in error scenarios
- Following better initialization sequence

Log: optimize node_names allocation timing in pipewire setup