### PR TITLE
Add topological node arrangement

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set (HEADERS
   qpwgraph_connect.h
   qpwgraph_port.h
   qpwgraph_node.h
+  qpwgraph_toposort.h
   qpwgraph_item.h
   qpwgraph_sect.h
   qpwgraph_pipewire.h
@@ -41,6 +42,7 @@ set (SOURCES
   qpwgraph_connect.cpp
   qpwgraph_port.cpp
   qpwgraph_node.cpp
+  qpwgraph_toposort.cpp
   qpwgraph_item.cpp
   qpwgraph_sect.cpp
   qpwgraph_pipewire.cpp

--- a/src/qpwgraph_canvas.cpp
+++ b/src/qpwgraph_canvas.cpp
@@ -2047,7 +2047,12 @@ void qpwgraph_canvas::arrangeNodes (void)
 			// End of a rank; reset Y and move to the next column
 			std::cout << "TOPO: next rank: from " << current_rank << " to " << node->depth() << std::endl;
 			y = ymin;
-			x += rankMaxWidth[current_rank] + xpad;
+
+			// XXX restore if FIXME from qpwgraph_toposort.cpp is fixed (node->depth() - current_rank)
+			// XXX int xpad_count = (node->depth() - current_rank)
+			int xpad_count = 1; // XXX
+
+			x += rankMaxWidth[current_rank] + xpad_count * xpad;
 			current_rank = node->depth();
 		}
 

--- a/src/qpwgraph_canvas.cpp
+++ b/src/qpwgraph_canvas.cpp
@@ -1969,8 +1969,7 @@ void qpwgraph_canvas::arrangeNodes (void)
 	// TODO: extract spacing values to constants or parameters
 	// TODO: right-align sources?  center-align middle nodes? left-align sinks?  This would require two passes over each rank.
 	// TODO: never go below 0,0 for xmin/ymin?
-	// FIXME: canvas area isn't (always?) updated when items are moved
-	// FIXME: canvas isn't always fully redrawn, resulting in leftover borders and lines
+	// FIXME: items sometimes end up on very edge of scroll area
 	QRectF bounds = m_scene->itemsBoundingRect();
 	float xmin = bounds.left();
 	float ymin = bounds.top();
@@ -1999,8 +1998,7 @@ void qpwgraph_canvas::arrangeNodes (void)
 	ensureVisible(sorted.last());
 	ensureVisible(sorted.first());
 
-	// FIXME: doesn't prevent garbage left on canvas
-	invalidateScene(QRectF(xmin, ymin, x + max_width, max_y));
+	m_scene->invalidate();
 }
 
 

--- a/src/qpwgraph_canvas.cpp
+++ b/src/qpwgraph_canvas.cpp
@@ -2128,6 +2128,7 @@ void qpwgraph_canvas::arrangeNodes(void)
 	}
 	
 	// Place all fake sources at first rank, and all sink nodes at final rank
+	// Also extract max size values needed for next loop
 	float max_width = 0;
 	foreach (qpwgraph_node *node, m_nodes) {
 		if (nodeIsTrueSink(node)) {
@@ -2147,13 +2148,17 @@ void qpwgraph_canvas::arrangeNodes(void)
 
 	// Place nodes based on topo sort
 	// TODO: extract spacing values to constants or parameters
-	QRectF bounds = boundingRect();
-	float xmin = bounds.left();
-	float ymin = bounds.top();
+	// TODO: right-align sources?  center-align middle nodes? left-align sinks?
+	// TODO: scroll to rearranged nodes in case nodes were super spread out
+	// TODO: never go below 0,0 for xmin/ymin?
+	QRectF bounds = m_scene->itemsBoundingRect();
+	float xmin = bounds.left() + 40;
+	float ymin = bounds.top() + 40;
 	float x = xmin, y = ymin;
 	int current_rank = 0;
 	foreach (qpwgraph_node *node, sorted) {
 		if (node->depth() > current_rank) {
+			// End of a rank; reset Y and move to the next column
 			y = ymin;
 			x += max_width * 2 + 20;
 			current_rank = node->depth();

--- a/src/qpwgraph_canvas.cpp
+++ b/src/qpwgraph_canvas.cpp
@@ -1946,6 +1946,20 @@ void qpwgraph_canvas::repelOverlappingNodesAll (
 }
 
 
+// Rearrange nodes by type and connection.
+void qpwgraph_canvas::arrangeNodes(void)
+{
+	float offset = 15;
+
+	// TODO: sort nodes topologically
+	// TODO: place nodes based on topo sort
+	foreach (qpwgraph_node *node, m_nodes) {
+		node->setPos(node->pos() + QPointF(offset, 0));
+		offset = -offset;
+	}
+}
+
+
 // Gesture event handlers.
 //
 bool qpwgraph_canvas::event ( QEvent *event )

--- a/src/qpwgraph_canvas.cpp
+++ b/src/qpwgraph_canvas.cpp
@@ -2068,6 +2068,10 @@ void qpwgraph_canvas::arrangeNodes (void)
 
 	// Move columns vertically for shorter and neater wires
 	for (int i = 1; i <= maxRank; i++) {
+		if (!rankNodes.contains(i)) {
+			continue;
+		}
+
 		// Sort each column by average connection source port Y value
 		std::sort(rankNodes[i].begin(), rankNodes[i].end(), [](qpwgraph_node *n1, qpwgraph_node *n2) { return meanParentPortY({n1}) < meanParentPortY({n2}); });
 
@@ -2088,10 +2092,12 @@ void qpwgraph_canvas::arrangeNodes (void)
 		qreal parentY = meanParentPortY(rankNodes[i]);
 		qreal inputY = meanInputPortY(rankNodes[i]);
 		qreal delta = inputY - parentY;
-		foreach (qpwgraph_node *n, rankNodes[i]) {
-			float newY = n->pos().y() - delta;
-			std::cout << "TOPO: COLUMN SHIFT: Setting " << qpwgraph_toposort::debugNode(n) << " Y from " << n->pos().y() << " to " << newY << std::endl;
-			n->setPos(n->pos().x(), newY);
+		if (std::isfinite(delta)) {
+			foreach (qpwgraph_node *n, rankNodes[i]) {
+				float newY = n->pos().y() - delta;
+				std::cout << "TOPO: COLUMN SHIFT: Setting " << qpwgraph_toposort::debugNode(n) << " Y from " << n->pos().y() << " to " << newY << std::endl;
+				n->setPos(n->pos().x(), newY);
+			}
 		}
 	}
 

--- a/src/qpwgraph_canvas.h
+++ b/src/qpwgraph_canvas.h
@@ -175,6 +175,9 @@ public:
 	void repelOverlappingNodesAll(
 		qpwgraph_move_command *move_command = nullptr);
 
+	// Arrange nodes by connection
+	void arrangeNodes();
+
 	// Graph colors management.
 	void setPortTypeColor(uint port_type, const QColor& color);
 	const QColor& portTypeColor(uint port_type);

--- a/src/qpwgraph_main.cpp
+++ b/src/qpwgraph_main.cpp
@@ -383,6 +383,10 @@ qpwgraph_main::qpwgraph_main (
 		SIGNAL(triggered(bool)),
 		SLOT(viewRefresh()));
 
+	QObject::connect(m_ui.viewArrangeAction,
+		SIGNAL(triggered(bool)),
+		SLOT(viewArrange()));
+
 	QObject::connect(m_ui.viewZoomInAction,
 		SIGNAL(triggered(bool)),
 		m_ui.graphCanvas, SLOT(zoomIn()));
@@ -965,6 +969,12 @@ void qpwgraph_main::viewRefresh (void)
 	++m_thumb_update;
 
 	refresh();
+}
+
+
+void qpwgraph_main::viewArrange (void)
+{
+	m_ui.graphCanvas->arrangeNodes();
 }
 
 

--- a/src/qpwgraph_main.h
+++ b/src/qpwgraph_main.h
@@ -148,6 +148,8 @@ protected slots:
 	void viewCenter();
 	void viewRefresh();
 
+	void viewArrange();
+
 	void viewZoomRange(bool on);
 
 	void viewSortTypeAction();

--- a/src/qpwgraph_main.ui
+++ b/src/qpwgraph_main.ui
@@ -191,6 +191,8 @@
     <addaction name="viewConnectThroughNodesAction"/>
     <addaction name="separator"/>
     <addaction name="viewRefreshAction"/>
+    <addaction name="separator"/>
+    <addaction name="viewArrangeAction"/>
    </widget>
    <widget class="QMenu" name="helpMenu">
     <property name="title">
@@ -1254,6 +1256,11 @@
    </property>
    <property name="shortcut">
     <string/>
+   </property>
+  </action>
+  <action name="viewArrangeAction">
+   <property name="text">
+    <string>Arrange</string>
    </property>
   </action>
  </widget>

--- a/src/qpwgraph_node.cpp
+++ b/src/qpwgraph_node.cpp
@@ -45,6 +45,8 @@ qpwgraph_node::qpwgraph_node (
 		m_id(id), m_name(name), m_mode(mode), m_type(type),
 		m_num(0), m_name_ex(false)
 {
+	m_depth = -1;
+
 	QGraphicsPathItem::setZValue(0.0);
 
 	const QPalette pal;

--- a/src/qpwgraph_node.cpp
+++ b/src/qpwgraph_node.cpp
@@ -44,7 +44,7 @@ qpwgraph_node::qpwgraph_node (
 	: qpwgraph_item(nullptr),
 		m_id(id), m_name(name), m_mode(mode), m_type(type),
 		m_num(0), m_name_ex(false),
-		m_depth(-1)
+		m_depth(0)
 {
 	QGraphicsPathItem::setZValue(0.0);
 

--- a/src/qpwgraph_node.cpp
+++ b/src/qpwgraph_node.cpp
@@ -43,10 +43,9 @@ qpwgraph_node::qpwgraph_node (
 	uint id, const QString& name, qpwgraph_item::Mode mode, uint type )
 	: qpwgraph_item(nullptr),
 		m_id(id), m_name(name), m_mode(mode), m_type(type),
-		m_num(0), m_name_ex(false)
+		m_num(0), m_name_ex(false),
+		m_depth(-1)
 {
-	m_depth = -1;
-
 	QGraphicsPathItem::setZValue(0.0);
 
 	const QPalette pal;
@@ -263,6 +262,19 @@ bool qpwgraph_node::isNodeNameEx (void) const
 QString qpwgraph_node::nodeNameEx (void) const
 {
 	return (m_name_ex ? m_name : nodeName());
+}
+
+
+// Topological sort depth (distance from a source node)
+void qpwgraph_node::setDepth (int depth)
+{
+	m_depth = depth;
+}
+
+
+int qpwgraph_node::depth(void) const
+{
+	return m_depth;
 }
 
 

--- a/src/qpwgraph_node.h
+++ b/src/qpwgraph_node.h
@@ -163,6 +163,8 @@ private:
 	qpwgraph_port::PortIds   m_port_ids;
 	qpwgraph_port::PortNames m_port_names;
 	QList<qpwgraph_port *>   m_ports;
+
+	int m_depth;
 };
 
 

--- a/src/qpwgraph_node.h
+++ b/src/qpwgraph_node.h
@@ -82,6 +82,9 @@ public:
 	bool isNodeNameEx() const;
 	QString nodeNameEx() const;
 
+	void setDepth(int depth);
+	int depth() const;
+
 	// Port-list methods.
 	qpwgraph_port *addPort(uint id, const QString& name, Mode mode, int type = 0);
 

--- a/src/qpwgraph_toposort.cpp
+++ b/src/qpwgraph_toposort.cpp
@@ -37,7 +37,9 @@ QList<qpwgraph_node *> qpwgraph_toposort::sort()
 	while (!unvisitedNodes.empty()) {
 		qsizetype initialCount = unvisitedNodes.size();
 
-		visitNode(QSet<qpwgraph_node *>(), unvisitedNodes.first());
+		qpwgraph_node *n = unvisitedNodes.first();
+		std::cout << "TOPO: CYCLE: breaking cycle with " << debugNode(n) << std::endl;
+		visitNode(QSet<qpwgraph_node *>(), n);
 
 		if (initialCount == unvisitedNodes.size()) {
 			std::cerr << "TOPO: \e[1;31mBUG\e[0m: unvisited count did not change during cycle breaking" << std::endl;
@@ -78,17 +80,17 @@ void qpwgraph_toposort::visitNode(QSet<qpwgraph_node *> path, qpwgraph_node *n)
 
 	foreach (qpwgraph_node *next, childNodes(n)) {
 		if (newPath.contains(next)) {
-			std::cout << "TOPO: already visited " << debugNode(n) << std::endl;
+			std::cout << "TOPO: CYCLE: already visited " << debugNode(n) << std::endl;
 			continue;
 		}
 
-		// FIXME: this can push graph cycles out to a crazy high rank if there are inbound connections to nodes
-		// in the feedback loop (basically length of the feedback loop plus one?)
 		int newDepth = qMax(n->depth() + 1, next->depth());
 		std::cout << "TOPO: setting " << debugNode(next) << " depth from " << next->depth() << " to " << newDepth << std::endl;
 		next->setDepth(newDepth);
 
-		visitNode(newPath, next);
+		if (!visitedNodes.contains(next)) {
+			visitNode(newPath, next);
+		}
 	}
 }
 

--- a/src/qpwgraph_toposort.cpp
+++ b/src/qpwgraph_toposort.cpp
@@ -106,9 +106,9 @@ void qpwgraph_toposort::visitNode(QSet<qpwgraph_node *> path, qpwgraph_node *n)
 		// b -> c
 		// d -> e
 		// e -> c
-		if (!visitedNodes.contains(next)) {
+		// XXX if (!visitedNodes.contains(next)) {
 			visitNode(newPath, next);
-		}
+		// XXX }
 	}
 }
 

--- a/src/qpwgraph_toposort.cpp
+++ b/src/qpwgraph_toposort.cpp
@@ -172,6 +172,39 @@ QSet<qpwgraph_node *> qpwgraph_toposort::childNodes(qpwgraph_node *n)
 	return children;
 }
 
+QSet<qpwgraph_port *> qpwgraph_toposort::connectedParentPorts(qpwgraph_node *n)
+{
+	QSet<qpwgraph_port *> portList;
+
+	foreach (qpwgraph_port *p, n->ports()) {
+		if (!p->isInput()) {
+			continue;
+		}
+
+		foreach (qpwgraph_connect *c, p->connects()) {
+			if (c->port1()->portNode() == c->port2()->portNode()) {
+				// self feedback
+				continue;
+			}
+
+			if (c->port1()->portNode() == n) {
+				portList << c->port2();
+			} else {
+				portList << c->port1();
+			}
+		}
+	}
+
+	return portList;
+}
+
+QSet<qpwgraph_port *> qpwgraph_toposort::connectedInputPorts(qpwgraph_node *n)
+{
+	QList<qpwgraph_port *> portList;
+	std::copy_if(n->ports().begin(), n->ports().end(), std::back_inserter(portList), [](qpwgraph_port *p) { return p->connects().size() > 0; });
+	return QSet<qpwgraph_port *>(portList.begin(), portList.end());
+}
+
 bool qpwgraph_toposort::compareNodes(qpwgraph_node *n1, qpwgraph_node *n2)
 {
 	if (n1->depth() < n2->depth()) {

--- a/src/qpwgraph_toposort.cpp
+++ b/src/qpwgraph_toposort.cpp
@@ -1,0 +1,242 @@
+#include "qpwgraph_toposort.h"
+#include "qpwgraph_connect.h"
+
+#include <algorithm>
+#include <iostream>
+
+qpwgraph_toposort::qpwgraph_toposort(QList<qpwgraph_node *> nodes) :
+	inputNodes(nodes), unvisitedNodes(nodes), visitedNodes()
+{
+}
+
+void qpwgraph_toposort::sort()
+{
+	std::cout << "TOPO: beginning sorting" << std::endl;
+
+	foreach (qpwgraph_node *n, inputNodes) {
+		if (nodeIsTrueSource(n)) {
+			n->setDepth(0);
+		} else if (nodeIsTrueSink(n)) {
+			n->setDepth(2);
+		} else {
+			n->setDepth(1);
+		}
+	}
+
+	std::sort(inputNodes.begin(), inputNodes.end(), compareNodes);
+	std::sort(unvisitedNodes.begin(), unvisitedNodes.end(), compareNodes);
+
+	// Visit sources
+	foreach (qpwgraph_node *n, inputNodes) {
+		if (nodeIsEffectiveSource(n)) {
+			visitNode(QSet<qpwgraph_node *>(), n);
+		}
+	}
+
+	// Break cycles
+	while (!unvisitedNodes.empty()) {
+		qsizetype initialCount = unvisitedNodes.size();
+
+		visitNode(QSet<qpwgraph_node *>(), unvisitedNodes.first());
+
+		if (initialCount == unvisitedNodes.size()) {
+			std::cerr << "TOPO: \e[1;31mBUG\e[0m: unvisited count did not change during cycle breaking" << std::endl;
+			break;
+		}
+	}
+}
+
+void qpwgraph_toposort::visitNode(QSet<qpwgraph_node *> path, qpwgraph_node *n)
+{
+	if (path.contains(n)) {
+		std::cout << "TOPO: already visited " << debugNode(n) << std::endl;
+		return;
+	}
+
+	unvisitedNodes.removeOne(n);
+	visitedNodes << n;
+
+	auto newPath = QSet<qpwgraph_node *>(path);
+	newPath += n;
+
+	foreach (qpwgraph_node *next, childNodes(n)) {
+		visitNode(newPath, next);
+	}
+}
+
+qsizetype qpwgraph_toposort::countInputPorts(qpwgraph_node *n)
+{
+	return std::count_if(n->ports().begin(), n->ports().end(), [](qpwgraph_port *p) { return p->isInput(); });
+}
+
+qsizetype qpwgraph_toposort::countOutputPorts(qpwgraph_node *n)
+{
+	return std::count_if(n->ports().begin(), n->ports().end(), [](qpwgraph_port *p) { return p->isOutput(); });
+}
+
+// Counts connections that do not have the same source and destination node
+qsizetype qpwgraph_toposort::countExternalConnections(qpwgraph_node *n, bool input)
+{
+	qsizetype count = 0;
+
+	foreach (qpwgraph_port *p, n->ports()) {
+		if (p->isInput() == input) {
+			count += std::count_if(p->connects().begin(), p->connects().end(), [](qpwgraph_connect *c) { return c->port1()->portNode() != c->port2()->portNode(); });
+		}
+	}
+
+	return count;
+}
+
+qsizetype qpwgraph_toposort::countInputConnections(qpwgraph_node *n)
+{
+	return countExternalConnections(n, true);
+}
+
+qsizetype qpwgraph_toposort::countOutputConnections(qpwgraph_node *n)
+{
+	return countExternalConnections(n, false);
+}
+
+bool qpwgraph_toposort::nodeIsTrueSource(qpwgraph_node *n)
+{
+	return countInputPorts(n) == 0;
+}
+
+bool qpwgraph_toposort::nodeIsEffectiveSource(qpwgraph_node *n)
+{
+	return countInputConnections(n) == 0;
+}
+
+bool qpwgraph_toposort::nodeIsTrueSink(qpwgraph_node *n)
+{
+	return countOutputPorts(n) == 0;
+}
+
+// Returns all nodes directly connected to output ports of the given node
+QSet<qpwgraph_node *> qpwgraph_toposort::childNodes(qpwgraph_node *n)
+{
+	auto children = QSet<qpwgraph_node *>();
+
+	foreach (qpwgraph_port *p, n->ports()) {
+		if (p->isInput()) {
+			continue;
+		}
+
+		foreach (qpwgraph_connect *c, p->connects()) {
+			qpwgraph_node *n1 = c->port1()->portNode();
+			qpwgraph_node *n2 = c->port2()->portNode();
+
+			if (n1 == n2) {
+				continue;
+			}
+
+			if (n1 == n) {
+				children << n2;
+			} else {
+				children << n1;
+			}
+		}
+	}
+
+	return children;
+}
+
+bool qpwgraph_toposort::compareNodes(qpwgraph_node *n1, qpwgraph_node *n2)
+{
+	if (n1->depth() < n2->depth()) {
+		std::cout << "n1 depth < n2 depth" << std::endl;
+		return true;
+	}
+	if (n2->depth() < n1->depth()) {
+		std::cout << "n2 depth < n1 depth" << std::endl;
+		return false;
+	}
+
+	if (n1->ports().empty() && !n2->ports().empty()) {
+		std::cout << "n1 no ports" << std::endl;
+		return true;
+	}
+	if (n2->ports().empty() && !n1->ports().empty()) {
+		std::cout << "n2 no ports" << std::endl;
+		return false;
+	}
+
+	if (!(n1->ports().empty() || n2->ports().empty())) {
+		if (n1->ports().first()->portType() < n2->ports().first()->portType()) {
+			std::cout << "n1 port type" << std::endl;
+			return true;
+		}
+		if (n2->ports().first()->portType() < n1->ports().first()->portType()) {
+			std::cout << "n2 port type" << std::endl;
+			return false;
+		}
+	}
+
+	if (countInputPorts(n1) < countInputPorts(n2)) {
+		std::cout << "n1 input port count" << std::endl;
+		return true;
+	}
+	if (countInputPorts(n2) < countInputPorts(n1)) {
+		std::cout << "n2 input port count" << std::endl;
+		return false;
+	}
+
+	if (countOutputPorts(n1) < countOutputPorts(n2)) {
+		std::cout << "n1 output port count" << std::endl;
+		return true;
+	}
+	if (countOutputPorts(n2) < countOutputPorts(n1)) {
+		std::cout << "n2 output port count" << std::endl;
+		return false;
+	}
+
+	return false;
+}
+
+QString qpwgraph_toposort::modeName(qpwgraph_item::Mode mode)
+{
+	switch(mode) {
+		case qpwgraph_item::Mode::None:
+			return "None";
+
+		case qpwgraph_item::Mode::Input:
+			return "Input";
+
+		case qpwgraph_item::Mode::Output:
+			return "Output";
+
+		case qpwgraph_item::Mode::Duplex:
+			return "Duplex";
+	}
+
+	return "UNKNOWN/BUG";
+}
+
+std::string qpwgraph_toposort::debugNode(qpwgraph_node *n)
+{
+	int color = (n->nodeId() * 773) % 200 + 20;
+
+	QString s = "\e[38;5;" + QString::number(color) + "m" +
+			modeName(n->nodeMode()) + " node d" + QString::number(n->depth()) + " id" +
+			QString::number(n->nodeId()) + " / " + n->nodeName() +
+			"\e[37m";
+
+	return s.toStdString();
+}
+
+std::string qpwgraph_toposort::debugConnection(qpwgraph_connect *c)
+{
+	qpwgraph_port *fromPort = c->port1();
+	qpwgraph_node *fromNode = fromPort->portNode();
+
+	qpwgraph_port *toPort = c->port2();
+	qpwgraph_node *toNode = toPort->portNode();
+
+	QString s = "connection " +
+		QString::fromStdString(debugNode(fromNode)) + ":" + fromPort->portName().split(':').last() +
+		" -> " +
+		QString::fromStdString(debugNode(toNode)) + ":" + toPort->portName().split(':').last();
+
+	return s.toStdString();
+}

--- a/src/qpwgraph_toposort.cpp
+++ b/src/qpwgraph_toposort.cpp
@@ -88,6 +88,24 @@ void qpwgraph_toposort::visitNode(QSet<qpwgraph_node *> path, qpwgraph_node *n)
 		std::cout << "TOPO: setting " << debugNode(next) << " depth from " << next->depth() << " to " << newDepth << std::endl;
 		next->setDepth(newDepth);
 
+		// FIXME: fixes some issues with cyclic graphs but prevents
+		// updating depth in parallel graphs
+		//
+		// in1 -> a
+		// in1 -> b
+		// in1 -> c
+		// in1 -> d
+		// in1 -> e
+		// in2 -> e
+		// a -> out
+		// b -> out
+		// c -> out
+		// d -> out
+		// e -> out
+		// a -> b
+		// b -> c
+		// d -> e
+		// e -> c
 		if (!visitedNodes.contains(next)) {
 			visitNode(newPath, next);
 		}

--- a/src/qpwgraph_toposort.cpp
+++ b/src/qpwgraph_toposort.cpp
@@ -221,6 +221,16 @@ bool qpwgraph_toposort::compareNodes(qpwgraph_node *n1, qpwgraph_node *n2)
 		return false;
 	}
 
+	if (n1->nodeName() < n2->nodeName()) {
+		std::cout << "n1 node name" << std::endl;
+		return true;
+	}
+	if (n2->nodeName() < n1->nodeName()) {
+		std::cout << "n2 node name" << std::endl;
+		return false;
+	}
+
+	std::cout << "n1 n2 equal" << std::endl;
 	return false;
 }
 

--- a/src/qpwgraph_toposort.h
+++ b/src/qpwgraph_toposort.h
@@ -14,9 +14,7 @@ public:
 
 	qpwgraph_toposort(QList<qpwgraph_node *> nodes);
 
-	void sort();
-
-	QList<qpwgraph_node *> sortedNodes();
+	QList<qpwgraph_node *> sort();
 
 	static qsizetype countInputPorts(qpwgraph_node *n);
 	static qsizetype countOutputPorts(qpwgraph_node *n);
@@ -37,6 +35,7 @@ public:
 	static QString modeName(qpwgraph_item::Mode mode);
 	static std::string debugNode(qpwgraph_node *n);
 	static std::string debugConnection(qpwgraph_connect *c);
+	static std::string debugPath(QSet<qpwgraph_node *> path);
 
 private:
 	void visitNode(QSet<qpwgraph_node *> path, qpwgraph_node *n);

--- a/src/qpwgraph_toposort.h
+++ b/src/qpwgraph_toposort.h
@@ -20,7 +20,6 @@ public:
 	static qsizetype countOutputPorts(qpwgraph_node *n);
 
 	static qsizetype countExternalConnections(qpwgraph_node *n, bool input);
-
 	static qsizetype countInputConnections(qpwgraph_node *n);
 	static qsizetype countOutputConnections(qpwgraph_node *n);
 
@@ -29,6 +28,10 @@ public:
 	static bool nodeIsTrueSink(qpwgraph_node *n);
 
 	static QSet<qpwgraph_node *> childNodes(qpwgraph_node *n);
+
+	static QSet<qpwgraph_port *> connectedParentPorts(qpwgraph_node *n);
+	static QSet<qpwgraph_port *> connectedInputPorts(qpwgraph_node *n);
+	static QSet<qpwgraph_port *> connectedOutputPorts(qpwgraph_node *n);
 
 	static bool compareNodes(qpwgraph_node *n1, qpwgraph_node *n2);
 

--- a/src/qpwgraph_toposort.h
+++ b/src/qpwgraph_toposort.h
@@ -1,0 +1,50 @@
+#ifndef __qpwgraph_toposort_h
+#define __qpwgraph_toposort_h
+
+#include "qpwgraph_node.h"
+
+#include <string>
+
+#include <QList>
+#include <QSet>
+
+class qpwgraph_toposort
+{
+public:
+
+	qpwgraph_toposort(QList<qpwgraph_node *> nodes);
+
+	void sort();
+
+	QList<qpwgraph_node *> sortedNodes();
+
+	static qsizetype countInputPorts(qpwgraph_node *n);
+	static qsizetype countOutputPorts(qpwgraph_node *n);
+
+	static qsizetype countExternalConnections(qpwgraph_node *n, bool input);
+
+	static qsizetype countInputConnections(qpwgraph_node *n);
+	static qsizetype countOutputConnections(qpwgraph_node *n);
+
+	static bool nodeIsTrueSource(qpwgraph_node *n);
+	static bool nodeIsEffectiveSource(qpwgraph_node *n);
+	static bool nodeIsTrueSink(qpwgraph_node *n);
+
+	static QSet<qpwgraph_node *> childNodes(qpwgraph_node *n);
+
+	static bool compareNodes(qpwgraph_node *n1, qpwgraph_node *n2);
+
+	static QString modeName(qpwgraph_item::Mode mode);
+	static std::string debugNode(qpwgraph_node *n);
+	static std::string debugConnection(qpwgraph_connect *c);
+
+private:
+	void visitNode(QSet<qpwgraph_node *> path, qpwgraph_node *n);
+
+	// Instance variables
+	QList<qpwgraph_node *> inputNodes;
+	QList<qpwgraph_node *> unvisitedNodes;
+	QSet<qpwgraph_node *> visitedNodes;
+};
+
+#endif /* __qpwgraph_toposort_h */


### PR DESCRIPTION
Hi!  I know GitHub isn't the official development location for the project, but I wanted to create this PR here anyway to discuss whether it's something you'd find useful upstream.

----

This PR adds a topological sort command to qpwgraph.  It arranges nodes from left to right based on their connections.

<img width="1153" height="456" alt="image" src="https://github.com/user-attachments/assets/36c698b4-8238-440c-baeb-115d11686f5c" />

<img width="1387" height="438" alt="image" src="https://github.com/user-attachments/assets/1b174b88-ed92-415c-8b72-8bcbd839113d" />
