### PR TITLE
compile fix std::isfinite

### DIFF
--- a/src/qpwgraph_toposort.cpp
+++ b/src/qpwgraph_toposort.cpp
@@ -26,6 +26,7 @@
 #include "qpwgraph_connect.h"
 
 #include <QMap>
+#include <cmath>
 
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
I get in Ubuntu 22.04 running on a NVIDIA Jetson Orin Nano:

/home/voice-agent/qpwgraph/src/qpwgraph_toposort.cpp: In member function ‘const QHash<qpwgraph_node*, QPointF>& qpwgraph_toposort::arrange(const QRect&)’:
/home/voice-agent/qpwgraph/src/qpwgraph_toposort.cpp:137:26: error: ‘isfinite’ is not a member of ‘std’
137 | if (std::isfinite(delta)) {
| ^~~~~~~~

This include fixes the build.